### PR TITLE
Hide menu item

### DIFF
--- a/Hummingbird.xcodeproj/project.pbxproj
+++ b/Hummingbird.xcodeproj/project.pbxproj
@@ -313,7 +313,6 @@
 				6ED47B5D183BF3E800859244 /* Sources */,
 				6ED47B5E183BF3E800859244 /* Frameworks */,
 				6ED47B5F183BF3E800859244 /* Resources */,
-				5A7A88FD22814AE000731048 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -395,26 +394,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		5A7A88FD22814AE000731048 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "git status\n#version=$(git describe --always --tags --dirty)\nversion=$(git rev-parse --short @)\necho version: $version\ninfo_plist=$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Info.plist\nif [ $CONFIGURATION == \"Debug\" ]; then\n  /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $version\" $info_plist\nfi\n#/usr/libexec/PlistBuddy -c \"Add :GitVersion string $version\" $info_plist\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		65CF015E1F229C34002259F2 /* Sources */ = {

--- a/Hummingbird.xcodeproj/project.pbxproj
+++ b/Hummingbird.xcodeproj/project.pbxproj
@@ -558,7 +558,7 @@
 				INFOPLIST_FILE = "Hummingbird/Hummingbird-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 3.1.7;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.finestructure.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Hummingbird;
 				SDKROOT = macosx;
@@ -658,7 +658,7 @@
 				INFOPLIST_FILE = "Hummingbird/Hummingbird-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 3.1.7;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.finestructure.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Hummingbird;
 				SDKROOT = macosx;
@@ -863,7 +863,7 @@
 				INFOPLIST_FILE = "Hummingbird/Hummingbird-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 3.1.7;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.finestructure.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Hummingbird;
 				SDKROOT = macosx;
@@ -887,7 +887,7 @@
 				INFOPLIST_FILE = "Hummingbird/Hummingbird-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 3.1.7;
+				MARKETING_VERSION = 3.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "co.finestructure.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Hummingbird;
 				SDKROOT = macosx;

--- a/Hummingbird.xcodeproj/project.pbxproj
+++ b/Hummingbird.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		5A4619182286C4DA0078E1B2 /* ModifiertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4619172286C4DA0078E1B2 /* ModifiertTests.swift */; };
 		5A46191C2286C90B0078E1B2 /* Date+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A46191B2286C90B0078E1B2 /* Date+ext.swift */; };
 		5A46191D2286C90B0078E1B2 /* Date+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A46191B2286C90B0078E1B2 /* Date+ext.swift */; };
+		5A4ADE8525A848B100060686 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A45FBCC227B281E00DC184E /* AppDelegate.swift */; };
+		5A4ADE8825A848BF00060686 /* TipJarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A78DD1022F2FBF600D0F23D /* TipJarController.swift */; };
+		5A4ADE8B25A848C600060686 /* RegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA93C94231953AF00B268CF /* RegistrationController.swift */; };
 		5A4E24A5234900BF00A27B8F /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E24A4234900BF00A27B8F /* Functions.swift */; };
 		5A4E24A62349035000A27B8F /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E24A4234900BF00A27B8F /* Functions.swift */; };
 		5A5E275E232BBB35000F54E9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5E275D232BBB35000F54E9 /* Constants.swift */; };
@@ -408,10 +411,13 @@
 				5A16ED092333A05500AF12CE /* FeatureFlags.swift in Sources */,
 				5A45FBCE227B301E00DC184E /* Tracker.swift in Sources */,
 				5AE57A4822F72C090015B090 /* LicensingTests.swift in Sources */,
+				5A4ADE8525A848B100060686 /* AppDelegate.swift in Sources */,
+				5A4ADE8825A848BF00060686 /* TipJarController.swift in Sources */,
 				5A33F7B7250A450100956DD3 /* Corner.swift in Sources */,
 				5A8F9111227C418200B78C47 /* Modifiers.swift in Sources */,
 				5A4619182286C4DA0078E1B2 /* ModifiertTests.swift in Sources */,
 				5A8F9121227C81E600B78C47 /* CGPoint+ext.swift in Sources */,
+				5A4ADE8B25A848C600060686 /* RegistrationController.swift in Sources */,
 				5AB3A6FA2334E6AD00D40DBF /* Protocols.swift in Sources */,
 				5A45FBD1227B4BCE00DC184E /* PreferencesController.swift in Sources */,
 				5A2229A3228BE59600E4B95B /* Environment.swift in Sources */,

--- a/Hummingbird/AppDelegate.swift
+++ b/Hummingbird/AppDelegate.swift
@@ -61,14 +61,7 @@ extension AppDelegate {
             preferencesController.showWindow(nil)
             return
         } else {
-            statusItem = {
-                let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-                statusItem.menu = statusMenu
-                statusItem.button?.image = NSImage(named: "MenuIcon")
-                return statusItem
-            }()
-            statusMenu.autoenablesItems = false
-            versionMenuItem.title = "Version: \(appVersion())"
+            addStatusItemToMenubar()
         }
     }
 
@@ -91,6 +84,34 @@ extension AppDelegate: NSMenuDelegate {
             sendCoffeeMenuItem.isHidden = Current.featureFlags.commercial
         }
     }
+}
+
+// MARK:- Manage status item
+
+extension AppDelegate {
+
+    func addStatusItemToMenubar() {
+        statusItem = {
+            let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            statusItem.menu = statusMenu
+            statusItem.button?.image = NSImage(named: "MenuIcon")
+            return statusItem
+        }()
+        statusMenu.autoenablesItems = false
+        versionMenuItem.title = "Version: \(appVersion())"
+    }
+
+    func removeStatusItemFromMenubar() {
+        guard let statusItem = statusItem else { return }
+        NSStatusBar.system.removeStatusItem(statusItem)
+    }
+
+    func updateStatusItemVisibility() {
+        Current.defaults().bool(forKey: DefaultsKeys.hideMenuIcon.rawValue)
+            ? removeStatusItemFromMenubar()
+            : addStatusItemToMenubar()
+    }
+
 }
 
 

--- a/Hummingbird/AppDelegate.swift
+++ b/Hummingbird/AppDelegate.swift
@@ -56,14 +56,20 @@ extension AppDelegate {
     }
 
     override func awakeFromNib() {
-        statusItem = {
-            let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-            statusItem.menu = statusMenu
-            statusItem.button?.image = NSImage(named: "MenuIcon")
-            return statusItem
-        }()
-        statusMenu.autoenablesItems = false
-        versionMenuItem.title = "Version: \(appVersion())"
+        if Current.defaults().bool(forKey: DefaultsKeys.hideMenuIcon.rawValue) {
+            NSApp.activate(ignoringOtherApps: true)
+            preferencesController.showWindow(nil)
+            return
+        } else {
+            statusItem = {
+                let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+                statusItem.menu = statusMenu
+                statusItem.button?.image = NSImage(named: "MenuIcon")
+                return statusItem
+            }()
+            statusMenu.autoenablesItems = false
+            versionMenuItem.title = "Version: \(appVersion())"
+        }
     }
 
 }

--- a/Hummingbird/AppDelegate.swift
+++ b/Hummingbird/AppDelegate.swift
@@ -56,12 +56,12 @@ extension AppDelegate {
     }
 
     override func awakeFromNib() {
-        if Current.defaults().bool(forKey: DefaultsKeys.hideMenuIcon.rawValue) {
+        if Current.defaults().bool(forKey: DefaultsKeys.showMenuIcon.rawValue) {
+            addStatusItemToMenubar()
+        } else {
             NSApp.activate(ignoringOtherApps: true)
             preferencesController.showWindow(nil)
             return
-        } else {
-            addStatusItemToMenubar()
         }
     }
 
@@ -107,9 +107,9 @@ extension AppDelegate {
     }
 
     func updateStatusItemVisibility() {
-        Current.defaults().bool(forKey: DefaultsKeys.hideMenuIcon.rawValue)
-            ? removeStatusItemFromMenubar()
-            : addStatusItemToMenubar()
+        Current.defaults().bool(forKey: DefaultsKeys.showMenuIcon.rawValue)
+            ? addStatusItemToMenubar()
+            : removeStatusItemFromMenubar()
     }
 
 }

--- a/Hummingbird/Defaults.swift
+++ b/Hummingbird/Defaults.swift
@@ -16,13 +16,14 @@ enum DefaultsKeys: String {
     case moveModifiers
     case resizeModifiers
     case resizeFromNearestCorner
-    case hideMenuIcon
+    case showMenuIcon
 }
 
 
 let DefaultPreferences = [
     DefaultsKeys.moveModifiers.rawValue: Modifiers<Move>.defaultValue,
     DefaultsKeys.resizeModifiers.rawValue: Modifiers<Resize>.defaultValue,
+    DefaultsKeys.showMenuIcon.rawValue: NSNumber.init(booleanLiteral: true)
 ]
 
 

--- a/Hummingbird/Defaults.swift
+++ b/Hummingbird/Defaults.swift
@@ -16,6 +16,7 @@ enum DefaultsKeys: String {
     case moveModifiers
     case resizeModifiers
     case resizeFromNearestCorner
+    case hideMenuIcon
 }
 
 

--- a/Hummingbird/PreferencesController.swift
+++ b/Hummingbird/PreferencesController.swift
@@ -31,6 +31,8 @@ class PreferencesController: NSWindowController {
 
     @IBOutlet weak var resizeFromNearestCorner: NSButton!
     @IBOutlet weak var resizeInfoLabel: NSTextField!
+    
+    @IBOutlet weak var hideMenuIcon: NSButton!
 
     @IBOutlet weak var registrationStatusLabel: NSTextField!
     @IBOutlet weak var versionLabel: NSTextField!
@@ -47,7 +49,7 @@ class PreferencesController: NSWindowController {
         super.showWindow(sender)
         updateCopy()
     }
-
+    
 
     @IBAction func modifierClicked(_ sender: NSButton) {
         let moveButtons = [moveAlt, moveCommand, moveControl, moveFn, moveShift]
@@ -94,6 +96,18 @@ class PreferencesController: NSWindowController {
         Current.defaults().set(value, forKey: DefaultsKeys.resizeFromNearestCorner.rawValue)
         updateCopy()
     }
+    
+    @IBAction func hideMenuIconClicked(_ sender: Any) {
+        let value: NSNumber = {
+            var v = Current.defaults().bool(forKey:
+                DefaultsKeys.hideMenuIcon.rawValue)
+            v.toggle()
+            return NSNumber(booleanLiteral: v)
+        }()
+        Current.defaults().set(value, forKey:
+            DefaultsKeys.hideMenuIcon.rawValue)
+        updateCopy()
+    }
 }
 
 extension PreferencesController: NSWindowDelegate {
@@ -120,6 +134,9 @@ extension PreferencesController: NSWindowDelegate {
         }
 
         resizeFromNearestCorner.state = Current.defaults().bool(forKey: DefaultsKeys.resizeFromNearestCorner.rawValue)
+            ? .on : .off
+        
+        hideMenuIcon.state = Current.defaults().bool(forKey: DefaultsKeys.hideMenuIcon.rawValue)
             ? .on : .off
 
         updateCopy()

--- a/Hummingbird/PreferencesController.swift
+++ b/Hummingbird/PreferencesController.swift
@@ -32,7 +32,7 @@ class PreferencesController: NSWindowController {
     @IBOutlet weak var resizeFromNearestCorner: NSButton!
     @IBOutlet weak var resizeInfoLabel: NSTextField!
     
-    @IBOutlet weak var hideMenuIcon: NSButton!
+    @IBOutlet weak var showMenuIcon: NSButton!
 
     @IBOutlet weak var registrationStatusLabel: NSTextField!
     @IBOutlet weak var versionLabel: NSTextField!
@@ -137,7 +137,7 @@ extension PreferencesController: NSWindowDelegate {
         resizeFromNearestCorner.state = Current.defaults().bool(forKey: DefaultsKeys.resizeFromNearestCorner.rawValue)
             ? .on : .off
         
-        hideMenuIcon.state = Current.defaults().bool(forKey: DefaultsKeys.showMenuIcon.rawValue)
+        showMenuIcon.state = Current.defaults().bool(forKey: DefaultsKeys.showMenuIcon.rawValue)
             ? .on : .off
 
         updateCopy()

--- a/Hummingbird/PreferencesController.swift
+++ b/Hummingbird/PreferencesController.swift
@@ -107,6 +107,7 @@ class PreferencesController: NSWindowController {
         Current.defaults().set(value, forKey:
             DefaultsKeys.hideMenuIcon.rawValue)
         updateCopy()
+        (NSApp.delegate as? AppDelegate)?.updateStatusItemVisibility()
     }
 }
 

--- a/Hummingbird/PreferencesController.swift
+++ b/Hummingbird/PreferencesController.swift
@@ -100,12 +100,12 @@ class PreferencesController: NSWindowController {
     @IBAction func hideMenuIconClicked(_ sender: Any) {
         let value: NSNumber = {
             var v = Current.defaults().bool(forKey:
-                DefaultsKeys.hideMenuIcon.rawValue)
+                DefaultsKeys.showMenuIcon.rawValue)
             v.toggle()
             return NSNumber(booleanLiteral: v)
         }()
         Current.defaults().set(value, forKey:
-            DefaultsKeys.hideMenuIcon.rawValue)
+            DefaultsKeys.showMenuIcon.rawValue)
         updateCopy()
         (NSApp.delegate as? AppDelegate)?.updateStatusItemVisibility()
     }
@@ -137,7 +137,7 @@ extension PreferencesController: NSWindowDelegate {
         resizeFromNearestCorner.state = Current.defaults().bool(forKey: DefaultsKeys.resizeFromNearestCorner.rawValue)
             ? .on : .off
         
-        hideMenuIcon.state = Current.defaults().bool(forKey: DefaultsKeys.hideMenuIcon.rawValue)
+        hideMenuIcon.state = Current.defaults().bool(forKey: DefaultsKeys.showMenuIcon.rawValue)
             ? .on : .off
 
         updateCopy()

--- a/Hummingbird/PreferencesController.xib
+++ b/Hummingbird/PreferencesController.xib
@@ -19,6 +19,7 @@
                 <outlet property="resizeControl" destination="Vho-Wo-heQ" id="hHk-K6-Pom"/>
                 <outlet property="resizeFn" destination="ZoB-Ah-hDB" id="0dw-ya-nGD"/>
                 <outlet property="resizeFromNearestCorner" destination="bBy-AW-VTy" id="N3f-hX-Ymd"/>
+                <outlet property="hideMenuIcon" destination="pNU-or-TOn" id="maybe-some-special-id"/>
                 <outlet property="resizeInfoLabel" destination="kts-J2-yLG" id="FrF-JX-KO1"/>
                 <outlet property="resizeShift" destination="t0H-b4-ute" id="J8n-RE-hLE"/>
                 <outlet property="versionLabel" destination="eE9-Pq-pG9" id="Cny-Dl-tDQ"/>
@@ -193,6 +194,17 @@
                         </buttonCell>
                         <connections>
                             <action selector="resizeFromNearestCornerClicked:" target="-2" id="WcX-aB-Oy4"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pNU-or-TOn">
+                        <rect key="frame" x="30" y="68" width="198" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Hide menu icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="veU-QV-ewB">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="hideMenuIconClicked:" target="-2" id="mNd-W0-MRv"/>
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eE9-Pq-pG9">

--- a/Hummingbird/PreferencesController.xib
+++ b/Hummingbird/PreferencesController.xib
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesController" customModule="Hummingbird" customModuleProvider="target">
             <connections>
+                <outlet property="hideMenuIcon" destination="pNU-or-TOn" id="maybe-some-special-id"/>
                 <outlet property="moveAlt" destination="Sj9-Rc-bDN" id="UaS-BH-HzV"/>
                 <outlet property="moveCommand" destination="ihP-uA-QNF" id="zfQ-wo-1XF"/>
                 <outlet property="moveControl" destination="f0u-93-rmH" id="RUw-k3-LWp"/>
@@ -19,7 +20,6 @@
                 <outlet property="resizeControl" destination="Vho-Wo-heQ" id="hHk-K6-Pom"/>
                 <outlet property="resizeFn" destination="ZoB-Ah-hDB" id="0dw-ya-nGD"/>
                 <outlet property="resizeFromNearestCorner" destination="bBy-AW-VTy" id="N3f-hX-Ymd"/>
-                <outlet property="hideMenuIcon" destination="pNU-or-TOn" id="maybe-some-special-id"/>
                 <outlet property="resizeInfoLabel" destination="kts-J2-yLG" id="FrF-JX-KO1"/>
                 <outlet property="resizeShift" destination="t0H-b4-ute" id="J8n-RE-hLE"/>
                 <outlet property="versionLabel" destination="eE9-Pq-pG9" id="Cny-Dl-tDQ"/>
@@ -32,7 +32,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="421" height="313"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="421" height="313"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -199,7 +199,7 @@
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pNU-or-TOn">
                         <rect key="frame" x="30" y="68" width="198" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="check" title="Hide menu icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="veU-QV-ewB">
+                        <buttonCell key="cell" type="check" title="Show menu icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="veU-QV-ewB">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>

--- a/Hummingbird/PreferencesController.xib
+++ b/Hummingbird/PreferencesController.xib
@@ -8,7 +8,6 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesController" customModule="Hummingbird" customModuleProvider="target">
             <connections>
-                <outlet property="hideMenuIcon" destination="pNU-or-TOn" id="maybe-some-special-id"/>
                 <outlet property="moveAlt" destination="Sj9-Rc-bDN" id="UaS-BH-HzV"/>
                 <outlet property="moveCommand" destination="ihP-uA-QNF" id="zfQ-wo-1XF"/>
                 <outlet property="moveControl" destination="f0u-93-rmH" id="RUw-k3-LWp"/>
@@ -22,6 +21,7 @@
                 <outlet property="resizeFromNearestCorner" destination="bBy-AW-VTy" id="N3f-hX-Ymd"/>
                 <outlet property="resizeInfoLabel" destination="kts-J2-yLG" id="FrF-JX-KO1"/>
                 <outlet property="resizeShift" destination="t0H-b4-ute" id="J8n-RE-hLE"/>
+                <outlet property="showMenuIcon" destination="pNU-or-TOn" id="maybe-some-special-id"/>
                 <outlet property="versionLabel" destination="eE9-Pq-pG9" id="Cny-Dl-tDQ"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>


### PR DESCRIPTION
Supersedes #33 which adds the option to hide the menu bar icon.

Thanks a lot Robert (@ehni) for the gentle nudge to add this by doing all the hard work implementing it!

I've cherry-picked your main change but left out the status menu item singleton. I think it's fine in this case to just leave the add/remove/update methods on AppDelegate.

