### PR TITLE
Fix installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Or use [Homebrew](https://brew.sh):
 
 ```
 brew tap finestructure/Hummingbird
-brew install --cask Hummingbird
+brew install finestructure/hummingbird/hummingbird
 ```
 
 Hummingbird has been tested on macOS 10.14 Mojave and 10.15 Catalina but it should run on earlier macOS versions as well (macOS 10.11 or higher).


### PR DESCRIPTION
It seems that installing a package named "hummingbird" will actually download [another software](https://airvpn.org/hummingbird):

```
❯ brew info hummingbird
==> hummingbird: 1.2.1
https://airvpn.org/hummingbird
/opt/homebrew/Caskroom/hummingbird/3.3.0 (125B)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/hummingbird.rb
==> Name
Hummingbird
==> Description
OpenVPN 3 client
==> Artifacts
hummingbird-macos-arm64-1.2.1/hummingbird (Binary)
==> Analytics
install: 0 (30 days), 33 (90 days), 205 (365 days)
```

Updating the `brew install` command instructions to use the full path (including the tap) seems to fix the issue.